### PR TITLE
feat: add referral_url field and redirect to it

### DIFF
--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
@@ -18,7 +18,8 @@
   "vacancy_details",
   "admin_section",
   "apply_button_function",
-  "section_break_dluw",
+  "referral_url",
+  "section_break_isa0",
   "route"
  ],
  "fields": [
@@ -64,10 +65,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "section_break_dluw",
-   "fieldtype": "Section Break"
-  },
-  {
    "description": "Company or Organization seeking to Hire",
    "fieldname": "company",
    "fieldtype": "Data",
@@ -89,13 +86,24 @@
    "fieldtype": "Select",
    "label": "Apply Button Function",
    "options": "Local Email Client\nReferral Dialogue\nApplication Web Form"
+  },
+  {
+   "depends_on": "eval:doc.apply_button_function===\"Referral Dialogue\"",
+   "fieldname": "referral_url",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Referral URL"
+  },
+  {
+   "fieldname": "section_break_isa0",
+   "fieldtype": "Section Break"
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-02-11 09:24:47.266376",
+ "modified": "2025-02-14 16:45:53.194056",
  "modified_by": "Administrator",
  "module": "The Flying Fish",
  "name": "Job Vacancy",

--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/templates/job_vacancy.html
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/templates/job_vacancy.html
@@ -299,9 +299,9 @@
 	}
 
 	function ApplyByReferral() {
-		frappe.confirm('<strong>Continue to Redirect to Job Poster Site?</strong>\nhttps://phamos.eu/jobs',
+		frappe.confirm('<strong>Continue to Redirect to Job Poster Site?</strong>\n{{referral_url}}',
 			() => {
-				window.open("https://phamos.eu/jobs", "_blank");
+				window.open("{{referral_url}}", "_blank");
 			}, () => {
 				// action to perform if No is selected
 		});


### PR DESCRIPTION
https://git.phamos.eu/theflyingfish/theflyingfish/-/work_items/28

## The problem
When we select "Referral Dialog" in Apply Button Function select field, the "Apply Now" button just redirect to https://phamos.eu/jobs.

## Solution
Add a new field "Referral URL":
![Captura de pantalla de 2025-02-14 17-03-15](https://github.com/user-attachments/assets/bdd99417-5451-419b-b756-f1a7bf547d28)

Make the "Apply Now" button to take this url and redirect to it:
![Captura de pantalla de 2025-02-14 17-03-59](https://github.com/user-attachments/assets/82cb0738-3571-4cee-a1ce-5beeadd2b754)
