### PR TITLE
Add from and to email address to mailto

### DIFF
--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
@@ -18,7 +18,8 @@
   "vacancy_details",
   "admin_section",
   "apply_button_function",
-  "section_break_dluw",
+  "email_id",
+  "section_break_isa0",
   "route"
  ],
  "fields": [
@@ -64,10 +65,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "section_break_dluw",
-   "fieldtype": "Section Break"
-  },
-  {
    "description": "Company or Organization seeking to Hire",
    "fieldname": "company",
    "fieldtype": "Data",
@@ -89,13 +86,25 @@
    "fieldtype": "Select",
    "label": "Apply Button Function",
    "options": "Local Email Client\nReferral Dialogue\nApplication Web Form"
+  },
+  {
+   "fieldname": "section_break_isa0",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.apply_button_function===\"Local Email Client\"",
+   "fieldname": "email_id",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Email Id",
+   "options": "Email"
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-02-11 09:24:47.266376",
+ "modified": "2025-02-15 14:43:58.290238",
  "modified_by": "Administrator",
  "module": "The Flying Fish",
  "name": "Job Vacancy",

--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
@@ -95,16 +95,21 @@
    "depends_on": "eval:doc.apply_button_function===\"Local Email Client\"",
    "fieldname": "email_id",
    "fieldtype": "Data",
-   "hidden": 1,
    "label": "Email Id",
    "options": "Email"
+  },
+  {
+   "depends_on": "eval:doc.apply_button_function===\"Referral Dialogue\"",
+   "fieldname": "referral_url",
+   "fieldtype": "Data",
+   "label": "Referral URL"
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-02-15 14:43:58.290238",
+ "modified": "2025-02-15 15:00:30.587087",
  "modified_by": "Administrator",
  "module": "The Flying Fish",
  "name": "Job Vacancy",

--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/templates/job_vacancy.html
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/templates/job_vacancy.html
@@ -288,9 +288,10 @@
 							.replace(/<[^>]*>/g, ''); // Remove any HTML tags
 					
 						const from = frappe.session.user_email
+						const to = "{{email_id}}"
 						const subject = encodeURIComponent("{{ vacancy_title }} Job Offer");
 						const body = encodeURIComponent(emailBody);
-						const mailto_link = `mailto:?subject=${subject}&body=${body}`;
+						const mailto_link = `mailto:?subject=${subject}&body=${body}&from=${from}&to=${to}`;
 						window.location.href = mailto_link;
 						} else {
 							frappe.throw(__('Email template not found'));


### PR DESCRIPTION
https://git.phamos.eu/theflyingfish/theflyingfish/-/work_items/27

## Problem

When we open the email client, the `from` and `to` email addresses is not set automatically.

## Solution

Add `from` and `to` email addresses in the mailto URL.

![image](https://github.com/user-attachments/assets/e1453f4a-1fbc-4f26-8832-1b4a60e41ac8)

![image](https://github.com/user-attachments/assets/db5ef822-8a46-4a95-964d-84e17556f94a)
