### PR TITLE
update job vacancy field properties

### DIFF
--- a/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
+++ b/theflyingfish/the_flying_fish/doctype/job_vacancy/job_vacancy.json
@@ -86,20 +86,22 @@
    "fieldname": "apply_button_function",
    "fieldtype": "Select",
    "label": "Apply Button Function",
-   "options": "Local Email Client\nReferral Dialogue\nApplication Web Form"
+   "options": "\nLocal Email Client\nReferral Dialogue\nApplication Web Form"
   },
   {
    "depends_on": "eval:doc.apply_button_function===\"Local Email Client\"",
    "fieldname": "email_id",
    "fieldtype": "Data",
    "label": "Email Id",
+   "mandatory_depends_on": "eval:doc.apply_button_function===\"Local Email Client\"",
    "options": "Email"
   },
   {
    "depends_on": "eval:doc.apply_button_function===\"Referral Dialogue\"",
    "fieldname": "referral_url",
    "fieldtype": "Data",
-   "label": "Referral URL"
+   "label": "Referral URL",
+   "mandatory_depends_on": "eval:doc.apply_button_function===\"Referral Dialogue\""
   },
   {
    "fieldname": "section_break_isa0",
@@ -110,7 +112,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-02-15 15:00:30.587087",
+ "modified": "2025-02-24 17:45:50.719907",
  "modified_by": "Administrator",
  "module": "The Flying Fish",
  "name": "Job Vacancy",


### PR DESCRIPTION
https://git.phamos.eu/theflyingfish/theflyingfish/-/work_items/28

Added mandatory_depends_on property for fields - email_id and  referral_url.
Added default empty line for select field - apply_button_function


<img width="714" alt="Screenshot 2025-02-24 at 17 41 26" src="https://github.com/user-attachments/assets/04e83cbb-ce4c-4a52-aa34-6383c622420c" />
<img width="1280" alt="Screenshot 2025-02-24 at 17 41 23" src="https://github.com/user-attachments/assets/06ca1dda-4f98-4d77-aee3-0dc6b1d7e7dc" />

if apply_button_function is empty then apply now button not visible-
<img width="1224" alt="Screenshot 2025-02-24 at 17 47 55" src="https://github.com/user-attachments/assets/d3b75d20-9dab-4de0-90d3-213e40e7963f" />
<img width="918" alt="Screenshot 2025-02-24 at 17 47 36" src="https://github.com/user-attachments/assets/f519309b-3822-41d3-b3e7-3d3aea0399f6" />

