### PR TITLE
remove css properties from button

### DIFF
--- a/theflyingfish/templates/generators/item/item_inquiry.html
+++ b/theflyingfish/templates/generators/item/item_inquiry.html
@@ -1,36 +1,10 @@
 {% if shopping_cart and shopping_cart.cart_settings.enabled %}
 {% set cart_settings = shopping_cart.cart_settings %}
-    {% if cart_settings.show_contact_us_button | int %}
-        <button class="btn btn-inquiry contact-us-btn" data-item-code="{{ doc.name }}">
-            {{ _('Contact Us') }}
-        </button>
-        <style>
-            .btn {
-                display: inline-block;
-                text-align: center;
-                cursor: pointer;
-                transition: background-color 0.3s, transform 0.2s;
-            }
-
-            .contact-us-btn {
-                padding: 12px 24px;
-                background-color: #6c757d;
-                color: #fff;
-                border: none;
-                border-radius: 5px;
-                font-size: 16px;
-            }
-
-            .contact-us-btn:hover {
-                background-color: #5a6268;
-                transform: scale(1.05);
-            }
-
-            .contact-us-btn:active {
-                transform: scale(1);
-            }
-        </style>
-    {% endif %}
+	{% if cart_settings.show_contact_us_button | int %}
+		<button class="btn btn-inquiry font-md w-30-40" data-item-code="{{ doc.name }}">
+			{{ _('Contact Us') }}
+		</button>
+	{% endif %}
 <script>
 {% include "templates/generators/item/item_inquiry.js" %}
 </script>


### PR DESCRIPTION
Parent : https://git.phamos.eu/theflyingfish/theflyingfish/-/issues/65
Child : https://git.phamos.eu/theflyingfish/theflyingfish/-/work_items/67

Removed css properties from contact us button.

<img width="1025" alt="Screenshot 2025-03-26 at 09 37 24" src="https://github.com/user-attachments/assets/e246beda-2824-4264-a778-e30e81364891" />
<img width="1024" alt="Screenshot 2025-03-26 at 09 37 35" src="https://github.com/user-attachments/assets/9bfcb507-b850-473d-b6f9-8cb00e07a53f" />
